### PR TITLE
fix incorrect dist-utils version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5f83b241c1cbf3ec6c4b8c6b908127e0c9ad7481c5d3145639524157fc4e1744
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
@@ -20,6 +20,9 @@ requirements:
   host:
     - python
     - pip
+    - importlib_metadata
+    - setuptools >=61
+    - setuptools_scm >=6.2
   run:
     - python
 


### PR DESCRIPTION
* Copied the way [matplotlib handle setuptools_scm](https://github.com/conda-forge/matplotlib-feedstock/blob/0d78a2c910b73fd3d62f758d11f1c692039cdaf2/recipe/meta.yaml#L44-L45), making it a host dependency.
* Built and tested locally, seems to do the job.
* Closes https://github.com/conda-forge/urwid-feedstock/issues/30

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
